### PR TITLE
fix: qodana scan only if java files changed

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -7,11 +7,15 @@ on:
       - dev
       - stage
       - production
+    paths:
+      - '**/*.java'    # only trigger when Java files change
   pull_request:
     branches:
       - dev
       - stage
       - production
+    paths:
+      - '**/*.java'    # only trigger when Java files change
 
 jobs:
   qodana:


### PR DESCRIPTION
## Description

Fixed the code quality workflow (that runs Qodana) to only execute if a `.java` file has changed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)